### PR TITLE
Add new property for specific backend role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | 2.2.0 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | 2.2.0 |
+| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | >= 2.2 |
 
 ## Modules
 
@@ -20,21 +20,20 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [opensearch_role.admin_full_access](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/role) | resource |
-| [opensearch_role.this](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/role) | resource |
-| [opensearch_roles_mapping.admin_full_access](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/roles_mapping) | resource |
-| [opensearch_roles_mapping.all_access](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/roles_mapping) | resource |
-| [opensearch_roles_mapping.mapping_this](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/roles_mapping) | resource |
-| [opensearch_roles_mapping.security_manager](https://registry.terraform.io/providers/opensearch-project/opensearch/2.2.0/docs/resources/roles_mapping) | resource |
+| [opensearch_role.admin_full_access](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/role) | resource |
+| [opensearch_role.this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/role) | resource |
+| [opensearch_roles_mapping.admin_full_access](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
+| [opensearch_roles_mapping.all_access](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
+| [opensearch_roles_mapping.mapping_this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
+| [opensearch_roles_mapping.security_manager](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/roles_mapping) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS Account id | `string` | n/a | yes |
-| <a name="input_admin_users"></a> [admin\_users](#input\_admin\_users) | n/a | `set(string)` | n/a | yes |
-| <a name="input_applications"></a> [applications](#input\_applications) | n/a | <pre>map(object({<br>    cluster_permissions = set(string)<br>    index_patterns      = set(string)<br>    allowed_actions     = set(string)<br>  }))</pre> | n/a | yes |
-| <a name="input_users"></a> [users](#input\_users) | n/a | `set(string)` | n/a | yes |
+| <a name="input_admin_users"></a> [admin\_users](#input\_admin\_users) | Set of your admin users | `set(string)` | n/a | yes |
+| <a name="input_applications"></a> [applications](#input\_applications) | Define the permission for each service role you want to create | <pre>map(object({<br>    backend_role_names  = set(string)<br>    cluster_permissions = set(string)<br>    index_patterns      = set(string)<br>    allowed_actions     = set(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_users"></a> [users](#input\_users) | Set of your normal users | `set(string)` | n/a | yes |
 
 ## Outputs
 

--- a/opensearch_dashboard.tf
+++ b/opensearch_dashboard.tf
@@ -21,7 +21,7 @@ resource "opensearch_roles_mapping" "mapping_this" {
   description = "Mapping AWS IAM backend role to ES role: ${each.key}"
 
   role_name     = opensearch_role.this[each.key].role_name
-  backend_roles = ["arn:aws:iam::${var.account_id}:role/${each.key}-role"]
+  backend_roles = each.value.backend_role_names
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,7 @@
-variable "account_id" {
-  description = "AWS Account id"
-  type        = string
-}
-
 variable "applications" {
   description = "Define the permission for each service role you want to create"
-  type = map(object({
+  type        = map(object({
+    backend_role_names  = set(string)
     cluster_permissions = set(string)
     index_patterns      = set(string)
     allowed_actions     = set(string)


### PR DESCRIPTION
Add property "backend_role_names" in Application-variable to allow the mapping of backend-roles from accounts