### PR TITLE
Read only role and audit logs

### DIFF
--- a/opensearch_dashboard.tf
+++ b/opensearch_dashboard.tf
@@ -62,3 +62,13 @@ resource "opensearch_roles_mapping" "security_manager" {
   role_name   = "security_manager"
   users       = tolist(var.admin_users)
 }
+
+resource "opensearch_roles_mapping" "read_only" {
+  description = "Map users to read_only role"
+  role_name   = "readall"
+  users       = tolist(var.users)
+}
+
+resource "opensearch_audit_config" "audit_config" {
+  enabled = var.enable_audit_logs
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "applications" {
   description = "Define the permission for each service role you want to create"
-  type        = map(object({
+  type = map(object({
     backend_role_names  = set(string)
     cluster_permissions = set(string)
     index_patterns      = set(string)
@@ -16,4 +16,10 @@ variable "admin_users" {
 variable "users" {
   type        = set(string)
   description = "Set of your normal users"
+}
+
+variable "enable_audit_logs" {
+  type        = bool
+  description = "Enable audit logs"
+  default     = false
 }


### PR DESCRIPTION
Map users to read_only role, and add variable for enabling audit logs in dashboard